### PR TITLE
Fixes 'was implicitly marked as commented due to the configuration.'

### DIFF
--- a/src/DateTimeWithMicroseconds.php
+++ b/src/DateTimeWithMicroseconds.php
@@ -60,4 +60,12 @@ class DateTimeWithMicroseconds extends Type
 
         throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Newer doctrine shows warning like this:
![image](https://user-images.githubusercontent.com/342641/135471474-0fd86add-75aa-473d-864f-d115676cbd0c.png)

This pull request should fix this issue.